### PR TITLE
fix of vim setup

### DIFF
--- a/vim/vim.ml
+++ b/vim/vim.ml
@@ -139,8 +139,9 @@ endfunction
 let s:opam_configuration['merlin'] = function('OpamConfMerlin')
 
 let s:opam_packages = ["ocp-indent", "ocp-index", "merlin"]
-let s:opam_check_cmdline = ["opam list --installed --short --safe --color=never"] + s:opam_packages
-let s:opam_available_tools = split(system(join(s:opam_check_cmdline)))
+let s:opam_check_cmdline = "opam list --installed --short --safe --color=never " + join(s:opam_packages, " ")
+" was systemlist used here
+let s:opam_available_tools = split(system(s:opam_check_cmdline))
 for tool in s:opam_packages
   " Respect package order (merlin should be after ocp-index)
   if count(s:opam_available_tools, tool) > 0


### PR DESCRIPTION
In version 0.4, vim setup is using the vim function "systemlist" that is
presumably supposed to split a system output into a list. Unfortunately,
this function does not seem to exist on current vim version.
This patch is proposing a substitution of systemlist by more common set
of functions.
